### PR TITLE
Added an encode routine for a CanId (#16)

### DIFF
--- a/src/driver/address.rs
+++ b/src/driver/address.rs
@@ -5,7 +5,11 @@
 pub struct Address(pub u8);
 
 impl Address {
+    /// Address representing broadcasts for destination specific PGNs
     pub const GLOBAL: Address = Address(0xFF);
+    /// Alias for the global address
+    pub const BROADCAST: Address = Address(0xFF);
+    /// The null address is used by ECUs without an address such as during address claiming
     pub const NULL: Address = Address(0xFE);
 }
 

--- a/src/driver/can_id.rs
+++ b/src/driver/can_id.rs
@@ -49,6 +49,14 @@ pub enum Type {
     Extended = 0x1,
 }
 
+#[derive(Debug, Clone)]
+pub struct EncodingError {
+    pub priority: Priority,
+    pub parameter_group_number: Pgn,
+    pub source_address: Address,
+    pub destination_address: Address,
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct CanId(u32);
@@ -69,6 +77,63 @@ impl CanId {
             Type::Standard => raw & CAN_SFF_MASK,
         };
         Self(raw)
+    }
+
+    /// Encodes a new extended ID using the discrete parts of an identifier
+    pub fn try_encode(
+        parameter_group_number: Pgn,
+        source_address: Address,
+        destination_address: Address,
+        priority: Priority,
+    ) -> Result<CanId, EncodingError> {
+        if destination_address != Address::GLOBAL && parameter_group_number.is_broadcast() {
+            return Err(EncodingError {
+                priority,
+                parameter_group_number,
+                source_address,
+                destination_address,
+            });
+        }
+        Ok(unsafe {
+            CanId::encode_unchecked(
+                parameter_group_number,
+                source_address,
+                destination_address,
+                priority,
+            )
+        })
+    }
+
+    /// Encodes a new extended ID using the discrete parts of an identifier but won't validate
+    /// your combination of PGN and destination address.
+    ///
+    /// # Safety
+    /// Calling this without validating your PGN and destination address combination may result in your PGN field
+    /// getting trashed. Specifically, the risk is when you are using a broadcast PGN but supply a non-0xFF
+    /// destination address.
+    pub unsafe fn encode_unchecked(
+        parameter_group_number: Pgn,
+        source_address: Address,
+        destination_address: Address,
+        priority: Priority,
+    ) -> CanId {
+        let mut raw_id: u32 = 0;
+
+        raw_id |= (priority as u32 & 0x07) << 26;
+        raw_id |= source_address.0 as u32;
+
+        if Address::GLOBAL == destination_address {
+            if (parameter_group_number.raw() & 0xF000) >= 0xF000 {
+                raw_id |= (parameter_group_number.raw() & 0x3FFFF) << 8;
+            } else {
+                raw_id |= (destination_address.0 as u32) << 8;
+                raw_id |= (parameter_group_number.raw() & 0x3FF00) << 8;
+            }
+        } else if (parameter_group_number.raw() & 0xF000) < 0xF000 {
+            raw_id |= (destination_address.0 as u32) << 8;
+            raw_id |= (parameter_group_number.raw() & 0x3FF00) << 8;
+        }
+        CanId::new(raw_id & CAN_EFF_MASK, Type::Extended)
     }
 
     /// Get the raw value of the CAN ID
@@ -187,5 +252,46 @@ mod tests {
 
         let can_id = CanId::new(0x18EEFF1C, Type::Extended);
         assert_eq!(can_id.pgn(), Pgn::from_raw(0x0EE00));
+    }
+
+    #[test]
+    fn test_encode() {
+        let encode_result = CanId::try_encode(
+            Pgn::from_raw(0x00EF00),
+            Address(0x81),
+            Address(0xF9),
+            Priority::Six,
+        );
+        let can_id = encode_result.expect("EF00 Message was not encodable");
+        assert_eq!(can_id.pgn(), Pgn::from_raw(0xEF00));
+        assert_eq!(can_id.destination_address(), Address(0xF9));
+        assert_eq!(can_id.source_address(), Address(0x81));
+        assert_eq!(can_id.priority(), Priority::Six);
+
+        let encode_result = CanId::try_encode(
+            Pgn::from_raw(0x00FF40),
+            Address(0x81),
+            Address(0xFF),
+            Priority::Six,
+        );
+        let can_id = encode_result.expect("FF40 Message was not encodable");
+        assert_eq!(can_id.pgn(), Pgn::from_raw(0xFF40));
+        assert_eq!(can_id.destination_address(), Address(0xFF));
+        assert_eq!(can_id.source_address(), Address(0x81));
+        assert_eq!(can_id.priority(), Priority::Six);
+
+        let encode_result = CanId::try_encode(
+            Pgn::from_raw(0x00FF40),
+            Address(0x81),
+            Address(0x0F),
+            Priority::Six,
+        );
+        assert!(matches!(encode_result, Err(_)));
+
+        let error_contents: EncodingError = encode_result.unwrap_err();
+        assert_eq!(error_contents.priority, Priority::Six);
+        assert_eq!(error_contents.source_address, Address(0x81));
+        assert_eq!(error_contents.destination_address, Address(0x0F));
+        assert_eq!(error_contents.parameter_group_number, Pgn::from_raw(0xFF40));
     }
 }


### PR DESCRIPTION
* Added an encode routine for a CanId that encodes a new extended Id using its various components.
* Added an alias "BROADCAST" address which is the same as "GLOBAL"